### PR TITLE
Update the dump and backups for database

### DIFF
--- a/apps/api/ansible/backup.yml
+++ b/apps/api/ansible/backup.yml
@@ -1,0 +1,26 @@
+---
+- name: Backup our databases somewhere safe
+  hosts:
+   - prod
+  remote_user: "deploy"
+  become: no
+
+  vars:
+    db_pass: "{{ lookup('env','MYSQL_PASSWORD') }}"
+
+  tasks:
+  - name: add the .my.cnf file to access without needing a password
+    template:
+      src: my.cnf.j2
+      dest: /home/deploy/.my.cnf
+
+    
+  - name: add the bash script to dump the databases
+    template:
+      src: backup_dbs.sh.j2
+      dest: /home/deploy/backup_dbs.sh
+      mode: "u=rwx,g=r,o=r"
+
+
+  - name: dump the small databases (all apart from the greencheck ones)
+    command: bash /home/deploy/backup_dbs.sh

--- a/apps/api/ansible/backup.yml
+++ b/apps/api/ansible/backup.yml
@@ -7,6 +7,8 @@
 
   vars:
     db_pass: "{{ lookup('env','MYSQL_PASSWORD') }}"
+    backup_user: "{{ lookup('env','BACKUP_USER') }}"
+    backup_host: "{{ lookup('env','BACKUP_HOST') }}"
 
   tasks:
   - name: add the .my.cnf file to access without needing a password
@@ -14,13 +16,8 @@
       src: my.cnf.j2
       dest: /home/deploy/.my.cnf
 
-    
   - name: add the bash script to dump the databases
     template:
       src: backup_dbs.sh.j2
       dest: /home/deploy/backup_dbs.sh
       mode: "u=rwx,g=r,o=r"
-
-
-  - name: dump the small databases (all apart from the greencheck ones)
-    command: bash /home/deploy/backup_dbs.sh

--- a/apps/api/ansible/backup_dbs.sh.j2
+++ b/apps/api/ansible/backup_dbs.sh.j2
@@ -1,23 +1,31 @@
+backup_and_shift () {
+    mysqldump --quick --single-transaction -u backup greencheck $1 | gzip > dumps/$1.sql.gz
+    scp dumps/$1.sql.gz {{ backup_user }}@{{ backup_host }}
+}
+
+# set up our datbase dump directory
+mkdir -p ./dumps
+
+echo "dumping greencheck tables 2012 through 2015 to dumps dir"
 mysqldump --quick --single-transaction -u backup greencheck \
     --ignore-table=greencheck.greencheck \
+    --ignore-table=greencheck.greencheck_2012 \
+    --ignore-table=greencheck.greencheck_2013 \
     --ignore-table=greencheck.greencheck_2014 \
     --ignore-table=greencheck.greencheck_2015 \
-    --ignore-table=greencheck.greencheck_2013 \
-    --ignore-table=greencheck.greencheck_2012 \
-    | gzip > dump.small_tables.sql.gz
+    | gzip > dumps/small_tables.sql.gz
 
 
-# scp local file to tilaa box
-scp dump.small_tables.sql.gz {{ backup_user}}@{{ backup_host }}
-rm dump.small_tables.sql.gz
+# scp local file to the tilaa box
+scp dumps/small_tables.sql.gz {{ backup_user}}@{{ backup_host }}
 
-# then repeat for each year
-for YEAR_TABLE in greencheck_2015 greencheck_2014 greencheck_2013 greencheck_2012 
+# then call backup_and_shift for each year
+for YEAR_TABLE in greencheck_2015 greencheck_2014 greencheck_2013 greencheck_2012 greencheck
 do
-    mysqldump --quick --single-transaction -u backup greencheck $YEAR_TABLE | gzip > dump.$YEAR_TABLE.sql.gz
-    scp dump.$YEAR_TABLE.sql.gz {{ backup_user}}@{{ backup_host }}
-    rm dump.$YEAR_TABLE.sql.gz
-done 
+    backup_and_shift $YEAR_TABLE
+done
 
-# then finally, the monster
-# mysql -u backup < backup.greencheck.sql
+rsync -vazuk dumps/ {{ backup_user}}@{{ backup_host }}:/backup/mysql/dumps/
+
+# remove all the files we've just copied to our backup destination
+rm -rf ./dumps

--- a/apps/api/ansible/backup_dbs.sh.j2
+++ b/apps/api/ansible/backup_dbs.sh.j2
@@ -1,0 +1,23 @@
+mysqldump --quick --single-transaction -u backup greencheck \
+    --ignore-table=greencheck.greencheck \
+    --ignore-table=greencheck.greencheck_2014 \
+    --ignore-table=greencheck.greencheck_2015 \
+    --ignore-table=greencheck.greencheck_2013 \
+    --ignore-table=greencheck.greencheck_2012 \
+    | gzip > dump.small_tables.sql.gz
+
+
+# scp local file to tilaa box
+scp dump.small_tables.sql.gz {{ backup_user}}@{{ backup_host }}
+rm dump.small_tables.sql.gz
+
+# then repeat for each year
+for YEAR_TABLE in greencheck_2015 greencheck_2014 greencheck_2013 greencheck_2012 
+do
+    mysqldump --quick --single-transaction -u backup greencheck $YEAR_TABLE | gzip > dump.$YEAR_TABLE.sql.gz
+    scp dump.$YEAR_TABLE.sql.gz {{ backup_user}}@{{ backup_host }}
+    rm dump.$YEAR_TABLE.sql.gz
+done 
+
+# then finally, the monster
+# mysql -u backup < backup.greencheck.sql

--- a/apps/api/ansible/my.cnf.j2
+++ b/apps/api/ansible/my.cnf.j2
@@ -1,0 +1,5 @@
+# {{ ansible_managed }}
+# Last run: {{ template_run_date }}
+
+[client]
+password={{ db_pass }}


### PR DESCRIPTION
This updates the existing backup processes, so we can run regular updates on a cronjobs again, and get them safely backed up for adjusting.

## Specific details 

### Flags for mysql dump

We use `--single-transaction` to avoid locking the database, and stopping being able to add new entries to the greencheck tables. We end up wrapping the dump in a single transaction, which:

> dumps the consistent state of the database at the time when START TRANSACTION was issued without blocking any applications. 

We use `--quick` to save memory, as otherwise the dump file may exhaust the memory available to the server.

## Separate dumps

We dump the files piecemeal, because when I tried dumping the entire database in one go, I kept running out of memory. When I look at the tables, like `greencheck_2012` compared to regular ol' `greencheck`, it makes me wonder if in future we can replace them with views to save space.

As it stands it takes about an hour to export all the data and copy off the prod server.

### To be handled in a separate issue

- Using ansible to set up a crontab entry to run this regularly

### Checking licences

I've set up FOSSA to run an automated check for licenses, and because the Ansible deployment cookbook is GPL, it was flagged up. As far as I can tell though, we are able to keep the GPL for that, and have the API codes with a separate license, so I've resolved that manually now.
