### PR TITLE
Setting up CI with Google Cloud Build - Resolves #2 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,11 +20,12 @@ COPY --from=composer /usr/bin/composer /usr/bin/composer
 # # set up the src
 RUN mkdir -p /app
 
-# # move
+#
+COPY runtests.sh /app/runtests.sh
+
+#
 COPY packages/greencheck/composer.json /app/composer.json
 WORKDIR /app/
 RUN /usr/bin/composer install
 
 COPY packages/greencheck /app/
-
-# RUN ./bin/phpunit -c phpunit.xml.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,26 +6,34 @@ ENV DEBIAN_FRONTEND=noninteractive
 ## install the deps for running greenchecks
 RUN apt-get update \
   && apt-get install git \
-  php-fpm php-pear php7.2-dev php7.2-mbstring php-mysql \
-  zip unzip  --yes \
-  && pecl install redis-4.0.1
+  php-fpm php-pear php7.2-dev php7.2-mbstring php7.2-bcmath php-mysql php7.2-curl \
+  mysql-client \
+  php7.2-redis \
+  zip unzip \
+  netcat --yes
 
 # so we can sanity check the box
-RUN apt-get install mysql-client --yes
+# RUN apt-get install mysql-client mysql-server redis --yes
+
+# RUN service mysql start
 
 # # fetch the composer image, and copy the composer binary
 # # so we can run composer later in our container
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 
-# # set up the src
+# set up the src
 RUN mkdir -p /app
 
-#
-COPY runtests.sh /app/runtests.sh
-
-#
 COPY packages/greencheck/composer.json /app/composer.json
+
 WORKDIR /app/
 RUN /usr/bin/composer install
 
+COPY wait-for /app/wait-for
+COPY runtests.sh /app/runtests.sh
+
+
 COPY packages/greencheck /app/
+
+
+# RUN ./bin/phpunit -c phpunit.xml.dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu
+
+# we're prompted if we don't add this
+ENV DEBIAN_FRONTEND=noninteractive
+
+## install the deps for running greenchecks
+RUN apt-get update \
+  && apt-get install git \
+  php-fpm php-pear php7.2-dev php7.2-mbstring php-mysql \
+  zip unzip  --yes \
+  && pecl install redis-4.0.1
+
+# # fetch the composer image, and copy the composer binary
+# # so we can run composer later in our container
+COPY --from=composer /usr/bin/composer /usr/bin/composer
+
+# # set up the src
+RUN mkdir -p /app
+
+# # move
+COPY packages/greencheck/composer.json /app/composer.json
+WORKDIR /app/
+RUN /usr/bin/composer install
+
+COPY packages/greencheck /app/
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN apt-get update \
   zip unzip  --yes \
   && pecl install redis-4.0.1
 
+# so we can sanity check the box
+RUN apt-get install mysql-client --yes
+
 # # fetch the composer image, and copy the composer binary
 # # so we can run composer later in our container
 COPY --from=composer /usr/bin/composer /usr/bin/composer
@@ -24,3 +27,4 @@ RUN /usr/bin/composer install
 
 COPY packages/greencheck /app/
 
+# RUN ./bin/phpunit -c phpunit.xml.dist

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,5 @@
+steps:
+  - name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/greencheck", "."]
+images:
+  - "gcr.io/$PROJECT_ID/greencheck"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,9 +1,15 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-t", "gcr.io/$PROJECT_ID/greencheck", "."]
-  - name: "docker/docker-compose:1.16.1"
+  - name: "docker/compose:1.23.2"
     args: ["up", "-d"]
-  - name: "docker/docker-compose:1.16.1"
-    args: ["run", "web", "bash -c './wait-for db:3306 -- ./runtests.sh"]
+  - name: "docker/compose:1.23.2"
+    args:
+      - "run"
+      - "web"
+      - "bash"
+      - "-c"
+      - "./wait-for db:3306 -- ./runtests.sh"
+
 images:
   - "gcr.io/$PROJECT_ID/greencheck"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,9 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
     args: ["build", "-t", "gcr.io/$PROJECT_ID/greencheck", "."]
+  - name: "docker/docker-compose:1.16.1"
+    args: ["up", "-d"]
+  - name: "docker/docker-compose:1.16.1"
+    args: ["run", "web", "bash -c './wait-for db:3306 -- ./runtests.sh"]
 images:
   - "gcr.io/$PROJECT_ID/greencheck"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+web:
+  image: greencheck
+
+  links:
+    - redis
+    - db
+
+redis:
+  image: redis:alpine
+
+db:
+  image: circleci/mysql:5.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 web:
   image: greencheck
-
+  command: ["bash", "/app/runtests.sh"]
   links:
     - redis
     - db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.7"
 services:
   web:
-    image: greencheck
+    image: gcr.io/prodsci-tgwf-0/greencheck
     # command: bash -c './wait-for db:3306 -- ./runtests.sh'
     # volumes:
     #   - type: bind

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,14 @@ version: "3.7"
 services:
   web:
     image: gcr.io/prodsci-tgwf-0/greencheck
-    # command: bash -c './wait-for db:3306 -- ./runtests.sh'
+    # uncomment this to mount the greencheck code
+    # so you don't need to rebuild the image on each change
     # volumes:
     #   - type: bind
     #     source: ./packages/greencheck
     #     target: /app
+    environment:
+      TGWF_CONFIG_FILE_PATH: /config.ci.yml
 
     links:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,19 @@
-web:
-  image: greencheck
-  command: ["bash", "/app/runtests.sh"]
-  links:
-    - redis
-    - db
+version: "3.7"
+services:
+  web:
+    image: greencheck
+    # command: bash -c './wait-for db:3306 -- ./runtests.sh'
+    # volumes:
+    #   - type: bind
+    #     source: ./packages/greencheck
+    #     target: /app
 
-redis:
-  image: redis:alpine
+    links:
+      - redis
+      - db
 
-db:
-  image: circleci/mysql:5.6
+  redis:
+    image: redis:alpine
+
+  db:
+    image: circleci/mysql:5.6

--- a/packages/greencheck/Readme.md
+++ b/packages/greencheck/Readme.md
@@ -13,4 +13,8 @@ pecl install redis
 
 ## Running the tests
 
+```
 bin/phpunit -c configuration.xml
+```
+
+There is also experimental docker support.

--- a/packages/greencheck/Readme.md
+++ b/packages/greencheck/Readme.md
@@ -19,4 +19,62 @@ bin/phpunit -c configuration.xml
 
 If you want to run all the tests without stopping when a test fails, change `stopOnFailure="true"` to stopOnFailure="false" in `phpunit.xml.dist`.
 
+## Docker Support
+
 There is also experimental docker support.
+
+Make sure you have Docker installed.
+
+Next make sure you have the correct `config.yml` file, set up, with the appropriate values.
+
+If you're _not_ using docker, and you have Redis and MySQL installed on your host machine, your config should look like so, so you connect to the local running Redis and MySQL servers:
+
+#### What non-docker config looks like:
+
+```
+greencheck:
+  db:
+    driver: pdo_mysql
+    host: localhost
+    user: your_db_user
+    password:
+    dbname: your_database_name
+  redis:
+    host: localhost
+```
+
+#### What a docker config looks like
+
+Because docker compose represents Redis and MySQL servers as separate services that the greencheck code connects to, you need to make sure this is reflected in the config file. Specifically, we set the hostnames to use `redis` and `db` matching the services in the `docker-compose.yml` file, and use the credentials the docker image expects by default :
+
+```yaml
+greencheck:
+  db:
+    driver: pdo_mysql
+    host: db
+    user: root
+    password:
+    dbname: circle_test
+  redis:
+    host: redis
+```
+
+#### Spinning up docker
+
+To spin up the set of services, use `docker-compose` up, to fetch the images, and start runnign them. Add the `-d` flag to make it run in the background:
+
+```
+docker-compose up -d
+```
+
+Once you have the containers running, you can access the container with the code by 'shelling into' the relevant container:
+
+```
+docker-compose run web bash
+```
+
+You can spin down the set of services with `docker-compose down` too:
+
+```
+docker-compose down
+```

--- a/packages/greencheck/Readme.md
+++ b/packages/greencheck/Readme.md
@@ -17,4 +17,6 @@ pecl install redis
 bin/phpunit -c configuration.xml
 ```
 
+If you want to run all the tests without stopping when a test fails, change `stopOnFailure="true"` to stopOnFailure="false" in `phpunit.xml.dist`.
+
 There is also experimental docker support.

--- a/packages/greencheck/phpunit.xml.dist
+++ b/packages/greencheck/phpunit.xml.dist
@@ -10,7 +10,7 @@ and open the template in the editor.
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         stopOnFailure="false">
+         stopOnFailure="true">
     <testsuites>
         <testsuite name="Greencheck">
             <directory>tests</directory>

--- a/packages/greencheck/src/Sitecheck/Cache.php
+++ b/packages/greencheck/src/Sitecheck/Cache.php
@@ -97,6 +97,16 @@ class Cache
         }
         return 'apc';
     }
+    /**
+     * @return string
+     */
+    public function getRedisHost ()
+    {
+        if (isset($this->config['greencheck']['redis']['host'])) {
+            return $this->config['greencheck']['redis']['host'];
+        }
+        return '127.0.0.1';
+    }
 
     /**
      * @todo Inject these dependencies in the constructor instead
@@ -106,15 +116,17 @@ class Cache
      */
     public function getCacheDriver($cachetype)
     {
+
         if ('memcache' == $cachetype) {
             $memcache = new \Memcache();
-            $memcache->connect('127.0.0.1', 11211);
+            $memcache->connect($host, 11211);
 
             $cache = new MemcacheCache();
             $cache->setMemcache($memcache);
         } elseif ('redis' == $cachetype) {
             $redis = new \Redis();
-            $redis->connect('redis', 6379);
+            $redishost = $this->getRedisHost();
+            $redis->connect($redishost, 6379);
 
             $cache = new RedisCache();
             $cache->setRedis($redis);

--- a/packages/greencheck/src/Sitecheck/Cache.php
+++ b/packages/greencheck/src/Sitecheck/Cache.php
@@ -109,6 +109,17 @@ class Cache
     }
 
     /**
+     * @return string
+     */
+    public function getMemcacheHost ()
+    {
+        if (isset($this->config['greencheck']['memcache']['host'])) {
+            return $this->config['greencheck']['memcache']['host'];
+        }
+        return '127.0.0.1';
+    }
+
+    /**
      * @todo Inject these dependencies in the constructor instead
      *
      * @param $cachetype
@@ -119,7 +130,8 @@ class Cache
 
         if ('memcache' == $cachetype) {
             $memcache = new \Memcache();
-            $memcache->connect($host, 11211);
+            $memcachehost = $this->getMemcacheHost();
+            $memcache->connect($memcachehost, 11211);
 
             $cache = new MemcacheCache();
             $cache->setMemcache($memcache);

--- a/packages/greencheck/src/Sitecheck/Cache.php
+++ b/packages/greencheck/src/Sitecheck/Cache.php
@@ -114,7 +114,7 @@ class Cache
             $cache->setMemcache($memcache);
         } elseif ('redis' == $cachetype) {
             $redis = new \Redis();
-            $redis->connect('127.0.0.1', 6379);
+            $redis->connect('redis', 6379);
 
             $cache = new RedisCache();
             $cache->setRedis($redis);

--- a/packages/greencheck/src/Sitecheck/Cache.php
+++ b/packages/greencheck/src/Sitecheck/Cache.php
@@ -130,15 +130,12 @@ class Cache
 
         if ('memcache' == $cachetype) {
             $memcache = new \Memcache();
-            $memcachehost = $this->getMemcacheHost();
-            $memcache->connect($memcachehost, 11211);
-
+            $memcache->connect($this->getMemcacheHost(), 11211);
             $cache = new MemcacheCache();
             $cache->setMemcache($memcache);
         } elseif ('redis' == $cachetype) {
             $redis = new \Redis();
-            $redishost = $this->getRedisHost();
-            $redis->connect($redishost, 6379);
+            $redis->connect($this->getRedisHost(), 6379);
 
             $cache = new RedisCache();
             $cache->setRedis($redis);

--- a/packages/greencheck/tests/bootstrap.php
+++ b/packages/greencheck/tests/bootstrap.php
@@ -3,7 +3,18 @@
  * Bootstrap doctrine and configuration
  *
  */
+
+function getConfigFilePath ()
+    {
+        if (getenv('TGWF_CONFIG_FILE_PATH')) {
+            return getenv('TGWF_CONFIG_FILE_PATH');
+        }
+        return '/tests/config.yml';
+    }
+
 $rootDir = __DIR__ . '/..';
+
+$config_file_path = __DIR__ . getConfigFilePath();
 
 if (!$loader = @include $rootDir .'/vendor/autoload.php') {
     $message = <<< EOF
@@ -21,9 +32,10 @@ EOF;
     die($message);
 }
 
-if (!file_exists($rootDir .'/tests/config.yml')) {
+if (!file_exists($config_file_path)) {
     $message = <<< EOF
-<p>No config.yml found. Please copy the config.dist.yml to config.yml and configure the settings in this file:</p>
+<p>No config.yml found - (\$config_file_path: $config_file_path)</p>
+<p>Please copy the config.dist.yml to config.yml and configure the settings in this file:</p>
 <pre>
     cp config.dist.yml config.yml
     vi config.yml
@@ -49,7 +61,7 @@ use Symfony\Component\Yaml\Parser;
 
 $yaml = new Parser();
 
-$yamlconfig = $yaml->parse(file_get_contents($rootDir .'/tests/config.yml'));
+$yamlconfig = $yaml->parse(file_get_contents($config_file_path));
 
 //configuration
 $config = new Configuration();

--- a/packages/greencheck/tests/bootstrap.php
+++ b/packages/greencheck/tests/bootstrap.php
@@ -14,7 +14,7 @@ function getConfigFilePath ()
 
 $rootDir = __DIR__ . '/..';
 
-$config_file_path = __DIR__ . getConfigFilePath();
+$configFilePath = __DIR__ . getConfigFilePath();
 
 if (!$loader = @include $rootDir .'/vendor/autoload.php') {
     $message = <<< EOF
@@ -32,9 +32,9 @@ EOF;
     die($message);
 }
 
-if (!file_exists($config_file_path)) {
+if (!file_exists($configFilePath)) {
     $message = <<< EOF
-<p>No config.yml found - (\$config_file_path: $config_file_path)</p>
+<p>No config.yml found - (looked at  \$configFilePath: $configFilePath)</p>
 <p>Please copy the config.dist.yml to config.yml and configure the settings in this file:</p>
 <pre>
     cp config.dist.yml config.yml
@@ -61,7 +61,7 @@ use Symfony\Component\Yaml\Parser;
 
 $yaml = new Parser();
 
-$yamlconfig = $yaml->parse(file_get_contents($config_file_path));
+$yamlconfig = $yaml->parse(file_get_contents($configFilePath));
 
 //configuration
 $config = new Configuration();

--- a/packages/greencheck/tests/config.ci.yml
+++ b/packages/greencheck/tests/config.ci.yml
@@ -1,12 +1,12 @@
 greencheck:
   db:
     driver: pdo_mysql
-    host: localhost
-    user: tgwf
-    password: tgwf
-    dbname: greencheck_test
+    host: db
+    user: root
+    password:
+    dbname: circle_test
   redis:
-    host: localhost
+    host: redis
   memcache:
     host: localhost
   cachetime: 7200 # Standard cachetime is 2 hours

--- a/packages/greencheck/tests/config.dist.yml
+++ b/packages/greencheck/tests/config.dist.yml
@@ -5,6 +5,8 @@ greencheck:
     user: tgwf
     password: tgwf
     dbname: greencheck_test
+  redis:
+    host: localhost
   cachetime: 7200 # Standard cachetime is 2 hours
   cache: true
   cachetype: redis

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-php --ini

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+php --ini

--- a/runtests.sh
+++ b/runtests.sh
@@ -1,0 +1,11 @@
+
+
+# clear the test db
+php ./tests/doctrine-cli.php orm:schema-tool:drop --force
+
+# create the test db
+php ./tests/doctrine-cli.php orm:schema-tool:create
+
+# run the test command
+./bin/phpunit -c phpunit.xml.dist
+

--- a/wait-for
+++ b/wait-for
@@ -1,0 +1,79 @@
+#!/bin/sh
+
+TIMEOUT=15
+QUIET=0
+
+echoerr() {
+  if [ "$QUIET" -ne 1 ]; then printf "%s\n" "$*" 1>&2; fi
+}
+
+usage() {
+  exitcode="$1"
+  cat << USAGE >&2
+Usage:
+  $cmdname host:port [-t timeout] [-- command args]
+  -q | --quiet                        Do not output any status messages
+  -t TIMEOUT | --timeout=timeout      Timeout in seconds, zero for no timeout
+  -- COMMAND ARGS                     Execute command with args after the test finishes
+USAGE
+  exit "$exitcode"
+}
+
+wait_for() {
+  for i in `seq $TIMEOUT` ; do
+    nc -z "$HOST" "$PORT" > /dev/null 2>&1
+    
+    result=$?
+    if [ $result -eq 0 ] ; then
+      if [ $# -gt 0 ] ; then
+        exec "$@"
+      fi
+      exit 0
+    fi
+    sleep 1
+  done
+  echo "Operation timed out" >&2
+  exit 1
+}
+
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    *:* )
+    HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+    PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+    shift 1
+    ;;
+    -q | --quiet)
+    QUIET=1
+    shift 1
+    ;;
+    -t)
+    TIMEOUT="$2"
+    if [ "$TIMEOUT" = "" ]; then break; fi
+    shift 2
+    ;;
+    --timeout=*)
+    TIMEOUT="${1#*=}"
+    shift 1
+    ;;
+    --)
+    shift
+    break
+    ;;
+    --help)
+    usage 0
+    ;;
+    *)
+    echoerr "Unknown argument: $1"
+    usage 1
+    ;;
+  esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+  echoerr "Error: you need to provide a host and port to test."
+  usage 2
+fi
+
+wait_for "$@"


### PR DESCRIPTION

This PR here introduces the necessary docker containers to run the green check tests in google cloud build CI.

When we push changes on any brancg with changes inside the `packages/greencheck` directory, we:

- spin up mysql and redis
- spin up an ubuntu instance with the php deps as close to production as I could reasonably set up
- run the phpunit tests
- tear everything down again

I've had to update `packages/greencheck/src/Sitecheck/Cache.php` to use the `redis` hostname, as docker really, really likes you to use separate services, and when I tried to run them on the same docker image to simulate our server, it was a _total_ pain to work with its networking.

So, we'll need to set some env variables or something to make the `cache.php` connect to the correct host, depending on whether we're in development, in CI or in production.

I'm almost _certainly_ using docker wrong, and we can probably end up with smaller docker images to ship around, but at least here we can run tests in a CI server.
