### PR TITLE
WIP - Add first test, to replicate the logger behaviour in the API for #9

### DIFF
--- a/packages/greencheck/src/LatestResult.php
+++ b/packages/greencheck/src/LatestResult.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Greencheck;
+namespace TGWF\Greencheck;
 
 use TGWF\Greencheck\SitecheckResult;
 

--- a/packages/greencheck/src/Sitecheck/Logger.php
+++ b/packages/greencheck/src/Sitecheck/Logger.php
@@ -65,8 +65,10 @@ class Logger
         $latest = new LatestResult();
         $latest->setResult($result);
 
+        $domainKey = "domains:$checkedUrl";
+
         $this->entityManager->persist($gc);
-        $this->redis->set("domains:$checkedUrl", json_encode($result));
+        $this->redis->set($domainKey, json_encode($latest));
         $this->entityManager->flush();
     }
 }

--- a/packages/greencheck/src/Sitecheck/Logger.php
+++ b/packages/greencheck/src/Sitecheck/Logger.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\EntityManager;
 use TGWF\Greencheck\Entity\Greencheck;
 use TGWF\Greencheck\Entity\GreencheckIp;
 use TGWF\Greencheck\SitecheckResult;
+use TGWF\Greencheck\LatestResult;
 
 class Logger
 {
@@ -61,10 +62,11 @@ class Logger
         $gc->setDatum(new \DateTime('now'));
         $gc->setIp(GreencheckIp::convertIpPresentationToDecimal($ip));
 
-        $gcJson = json_encode($result);
+        $latest = new LatestResult();
+        $latest->setResult($result);
 
         $this->entityManager->persist($gc);
-        $this->redis->set("domains:$checkedUrl", $gcJson);
+        $this->redis->set("domains:$checkedUrl", json_encode($result));
         $this->entityManager->flush();
     }
 }

--- a/packages/greencheck/tests/SitecheckAsTest.php
+++ b/packages/greencheck/tests/SitecheckAsTest.php
@@ -15,6 +15,8 @@ class SitecheckAsTest extends TestCase
      */
     protected $sitecheck = null;
 
+    protected $redis = null;
+
     public function setUp() :void
     {
         // reset database to known state
@@ -26,6 +28,10 @@ class SitecheckAsTest extends TestCase
         // Setup the cache
         $cache = new Sitecheck\Cache($config);
         $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
 
         // @todo mock these where needed
         $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
@@ -36,7 +42,7 @@ class SitecheckAsTest extends TestCase
         $dns = $this->createMock(Sitecheck\DnsFetcher::class);
         $dns->method('getIpAddressesForUrl')->will($this->returnValueMap(TestConfiguration::getIpUrlMapping()));
 
-        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, new Sitecheck\Logger($entityManager), 'test', $dns);
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test', $dns);
 
         //Cleanup all cache entries to correctly test
         $cache = $this->sitecheck->getCache();

--- a/packages/greencheck/tests/SitecheckCachingTest.php
+++ b/packages/greencheck/tests/SitecheckCachingTest.php
@@ -17,6 +17,8 @@ class SitecheckCachingTest extends TestCase
 
     protected $em = null;
 
+    protected $redis = null;
+
     public function setUp(): void
     {
         // reset database to known state
@@ -29,6 +31,11 @@ class SitecheckCachingTest extends TestCase
         // Setup the cache
         $cache = new Sitecheck\Cache($config);
         $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
+
 
         // @todo mock these where needed
         $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
@@ -36,7 +43,7 @@ class SitecheckCachingTest extends TestCase
         $greencheckAsRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckAs");
         $greencheckTldRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckTld");
 
-        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, new Sitecheck\Logger($entityManager), 'test');
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test');
 
         //Cleanup all cache entries to correctly test
         $cache = $this->sitecheck->getCache();

--- a/packages/greencheck/tests/SitecheckHashCacheTest.php
+++ b/packages/greencheck/tests/SitecheckHashCacheTest.php
@@ -1,0 +1,75 @@
+<?php
+require_once __DIR__ . '/TestConfiguration.php';
+
+use TGWF\Greencheck\Sitecheck;
+use TGWF\Greencheck\Table;
+use TGWF\Greencheck\Logger\SQLLogger;
+
+use Symfony\Component\Validator\ValidatorBuilder;
+use PHPUnit\Framework\TestCase;
+class SitecheckHashCachingTest extends TestCase
+{
+    /**
+     *
+     * @var Sitecheck
+     */
+    protected $sitecheck = null;
+
+    protected $redis = null;
+
+    protected $em = null;
+
+    public function setUp(): void
+    {
+        // reset database to known state
+        TestConfiguration::setupDatabase();
+
+        $config     = TestConfiguration::$config;
+        $entityManager   = TestConfiguration::$em;
+        $this->em = $entityManager;
+
+        // Setup the cache
+        $cache = new Sitecheck\Cache($config);
+        $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
+
+        // @todo mock these where needed
+        $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
+        $greencheckIpRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckIp");
+        $greencheckAsRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckAs");
+        $greencheckTldRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckTld");
+
+
+
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test');
+
+        //Cleanup all cache entries to correctly test
+        $cache = $this->sitecheck->getCache();
+        $cache->deleteAll();
+
+    }
+
+    public function testRunningCheckAddsToDomainCache()
+    {
+        $cache = $this->sitecheck->getCache();
+        // $cache = $this->sitecheck->getCacheObject();
+        // $redisCache = $cache->getCache();
+
+        $logger = new SQLLogger();
+        $this->em->getConnection()->getConfiguration()->setSQLLogger($logger);
+
+        $date = new \DateTime('now');
+
+        $result = $this->sitecheck->check('www.nu.nl');
+        $redis = $cache->getRedis();
+
+        $cachedUrlData = $redis->get('domains:www.nu.nl');
+
+        $jsonDecodedData = json_decode($cachedUrlData);
+        $this->assertEquals($date, $jsonDecodedData);
+    }
+
+}

--- a/packages/greencheck/tests/SitecheckHashCacheTest.php
+++ b/packages/greencheck/tests/SitecheckHashCacheTest.php
@@ -58,18 +58,23 @@ class SitecheckHashCachingTest extends TestCase
         // $cache = $this->sitecheck->getCacheObject();
         // $redisCache = $cache->getCache();
 
-        $logger = new SQLLogger();
-        $this->em->getConnection()->getConfiguration()->setSQLLogger($logger);
+        // $logger = new SQLLogger();
+        // $this->em->getConnection()->getConfiguration()->setSQLLogger($logger);
 
         $date = new \DateTime('now');
+        $formattedDate = $date->format("Y-m-d");
 
         $result = $this->sitecheck->check('www.nu.nl');
         $redis = $cache->getRedis();
 
+        $allKeys = $redis->keys("domains*");
+
         $cachedUrlData = $redis->get('domains:www.nu.nl');
 
         $jsonDecodedData = json_decode($cachedUrlData);
-        $this->assertEquals($date, $jsonDecodedData);
+        $this->assertEquals("www.nu.nl", $jsonDecodedData->url);
+        $this->assertEquals(false, $jsonDecodedData->green);
+        $this->assertStringContainsString($formattedDate, $jsonDecodedData->date);
     }
 
 }

--- a/packages/greencheck/tests/SitecheckLoggingTest.php
+++ b/packages/greencheck/tests/SitecheckLoggingTest.php
@@ -18,6 +18,8 @@ class SitecheckLoggingTest extends TestCase
 
     protected $em = null;
 
+    protected $redis = null;
+
     public function setUp(): void
     {
         // reset database to known state
@@ -30,6 +32,11 @@ class SitecheckLoggingTest extends TestCase
         // Setup the cache
         $cache = new Sitecheck\Cache($config);
         $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
+
 
         // @todo mock these where needed
         $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
@@ -37,7 +44,7 @@ class SitecheckLoggingTest extends TestCase
         $greencheckAsRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckAs");
         $greencheckTldRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckTld");
 
-        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, new Sitecheck\Logger($entityManager), 'test');
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test');
 
         //Cleanup all cache entries to correctly test
         $cache = $this->sitecheck->getCache();

--- a/packages/greencheck/tests/SitecheckTest.php
+++ b/packages/greencheck/tests/SitecheckTest.php
@@ -16,6 +16,8 @@ class SitecheckTest extends TestCase
 
     protected $em;
 
+    protected $redis = null;
+
     public function setUp(): void
     {
         // reset database to known state
@@ -28,6 +30,10 @@ class SitecheckTest extends TestCase
         // Setup the cache
         $cache = new Sitecheck\Cache($config);
         $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
 
         // @todo mock these where needed
         $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
@@ -38,7 +44,7 @@ class SitecheckTest extends TestCase
         $dns = $this->createMock(Sitecheck\DnsFetcher::class);
         $dns->method('getIpAddressesForUrl')->will($this->returnValueMap(TestConfiguration::getIpUrlMapping()));
 
-        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, new Sitecheck\Logger($entityManager), 'test', $dns);
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test', $dns);
 
         //Cleanup all cache entries to correctly test
         $cache = $this->sitecheck->getCache();

--- a/packages/greencheck/tests/SitecheckValidationTest.php
+++ b/packages/greencheck/tests/SitecheckValidationTest.php
@@ -16,6 +16,9 @@ class SitecheckValidationTest extends TestCase
      */
     protected $sitecheck = null;
 
+    protected $redis = null;
+
+
     public function setUp(): void
     {
         // reset database to known state
@@ -27,6 +30,10 @@ class SitecheckValidationTest extends TestCase
         // Setup the cache
         $cache = new Sitecheck\Cache($config);
         $cache->setCache('default');
+        $redisCache = $cache->getCache();
+        $redis = $redisCache->getRedis();
+
+        $logger = new Sitecheck\Logger($entityManager, $redis);
 
         // @todo mock these where needed
         $greencheckUrlRepository = $entityManager->getRepository("TGWF\Greencheck\Entity\GreencheckUrl");
@@ -37,7 +44,7 @@ class SitecheckValidationTest extends TestCase
         $dns = $this->createMock(Sitecheck\DnsFetcher::class);
         $dns->method('getIpAddressesForUrl')->will($this->returnValueMap(TestConfiguration::getIpUrlMapping()));
 
-        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, new Sitecheck\Logger($entityManager), 'test', $dns);
+        $this->sitecheck = new Sitecheck($greencheckUrlRepository, $greencheckIpRepository, $greencheckAsRepository, $greencheckTldRepository, $cache, $logger, 'test', $dns);
 
         //Cleanup all cache entries to correctly test
         $cache = $this->sitecheck->getCache();

--- a/packages/greencheck/tests/bootstrap.php
+++ b/packages/greencheck/tests/bootstrap.php
@@ -9,7 +9,7 @@ function getConfigFilePath ()
         if (getenv('TGWF_CONFIG_FILE_PATH')) {
             return getenv('TGWF_CONFIG_FILE_PATH');
         }
-        return '/tests/config.yml';
+        return '/config.yml';
     }
 
 $rootDir = __DIR__ . '/..';


### PR DESCRIPTION
This PR logs a domain, and the check results to a persistent datastructure in Redis.


**Tasks**

- add test to check we have green results in Redis after checking
- [x]  work out how to cast a `greencheck` in [logger.php](https://github.com/thegreenwebfoundation/thegreenwebfoundation/blob/ca-log-to-redis/packages/greencheck/src/Sitecheck/Logger.php#L51) to a dict/hash/associative array structure from a class
- [x]  make the logResult method log this to Redis
- [ ] work out ideal TTL
